### PR TITLE
Added rawBody to req

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,13 @@ dotenv.config()
 const app = express()
 const port = process.env.PORT || 3000
 
-app.use(express.json())
+app.use(
+    express.json({
+        verify: (req, res, buf) => {
+            req.rawBody = buf
+        },
+    })
+)
 app.use(cors())
 app.use(cookieParser())
 

--- a/src/routes/imageRouter.js
+++ b/src/routes/imageRouter.js
@@ -90,68 +90,64 @@ imageRouter.post(
 )
 
 //webhook for cloudinary moderation
-imageRouter.post(
-    '/cloudinary/webhook',
-    express.raw({ type: 'application/json' }),
-    async (req, res) => {
-        //verify that cloudinary is the client
-        const raw = req.body.toString('utf8')
-        const timestamp = req.header('X-Cld-Timestamp')
-        const signature = req.header('X-Cld-Signature')
+imageRouter.post('/cloudinary/webhook', async (req, res) => {
+    //verify that cloudinary is the client
+    const raw = req.rawBody.toString('utf8')
+    const timestamp = req.header('X-Cld-Timestamp')
+    const signature = req.header('X-Cld-Signature')
 
-        console.log(req.body)
-        console.log('---------')
-        console.log(raw)
-        console.log(timestamp)
-        console.log(signature)
+    console.log(req.body)
+    console.log('---------')
+    console.log(raw)
+    console.log(timestamp)
+    console.log(signature)
 
-        const isCloudinary = cloudinary.utils.verifyNotificationSignature(
-            raw,
-            timestamp,
-            signature,
-            600
-        )
+    const isCloudinary = cloudinary.utils.verifyNotificationSignature(
+        raw,
+        timestamp,
+        signature,
+        600
+    )
 
-        console.log(`Was it Cloudinary? ${isCloudinary}`)
-        if (!isCloudinary) {
-            return res.status(403).end()
-        }
+    console.log(`Was it Cloudinary? ${isCloudinary}`)
+    if (!isCloudinary) {
+        return res.status(403).end()
+    }
 
-        //Then use notification to update img
-        const data = JSON.parse(raw)
+    //Then use notification to update img
+    const data = JSON.parse(raw)
 
-        const { public_id, moderation_status, secure_url } = data
+    const { public_id, moderation_status, secure_url } = data
 
-        if (!public_id || !moderation_status) {
-            return res.status(200).end()
-        }
-
-        if (moderation_status !== 'approved') {
-            return res.status(200).end()
-        }
-
-        const url = secure_url || cloudinary.url(public_id)
-
-        const movieRes = await db.query(
-            `UPDATE movies
-             SET approved = true, img = $1
-             WHERE img_id = $2`,
-            [url, public_id]
-        )
-
-        if (movieRes.rowCount > 0) {
-            return res.status(200).end()
-        }
-
-        const playlistRes = await db.query(
-            `UPDATE playlists
-             SET approved = true, img = $1
-             WHERE img_id = $2`,
-            [url, public_id]
-        )
-
+    if (!public_id || !moderation_status) {
         return res.status(200).end()
     }
-)
+
+    if (moderation_status !== 'approved') {
+        return res.status(200).end()
+    }
+
+    const url = secure_url || cloudinary.url(public_id)
+
+    const movieRes = await db.query(
+        `UPDATE movies
+             SET approved = true, img = $1
+             WHERE img_id = $2`,
+        [url, public_id]
+    )
+
+    if (movieRes.rowCount > 0) {
+        return res.status(200).end()
+    }
+
+    const playlistRes = await db.query(
+        `UPDATE playlists
+             SET approved = true, img = $1
+             WHERE img_id = $2`,
+        [url, public_id]
+    )
+
+    return res.status(200).end()
+})
 
 export default imageRouter


### PR DESCRIPTION
Verifying the cloudinary signature requires the raw body of the request, which we have been throwing away immediately by using express.json.

I've altered this in server.js, so that rawBody is added to the request, so I can use it in the cloudinary verification.

Removed the useless middle ware line on the cloudinary POST web hook, which i thought would capture the raw body.
All other changes are just formatting... 